### PR TITLE
fix(cli): validate entry file extension before graph build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,29 @@ fn main() {
                 }
             };
 
+            // Validate entry file extension before expensive graph build
+            if entry.is_dir() {
+                eprintln!("error: '{}' is a directory, not a source file", entry.display());
+                std::process::exit(1);
+            }
+            let valid_extensions = lang_support.extensions();
+            let has_valid_ext = entry
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| valid_extensions.contains(&ext));
+            if !has_valid_ext {
+                let exts = valid_extensions
+                    .iter()
+                    .map(|e| format!(".{e}"))
+                    .collect::<Vec<_>>()
+                    .join("/");
+                eprintln!(
+                    "error: '{}' is not a source file (expected {exts})",
+                    entry.display()
+                );
+                std::process::exit(1);
+            }
+
             // Load or build graph
             let (graph, from_cache) = load_or_build_graph(&root, no_cache, lang_support.as_ref());
             eprintln!(


### PR DESCRIPTION
## Problem

Passing a non-source file (tsconfig.json, .gitignore) or a directory as
the entry point triggers a full dependency graph build (~1.3 s on large
projects) before the input is rejected. The extension is known before
the graph is needed.

## Fix

Check the entry path against the language's valid extensions and reject
directories immediately after project detection, before calling
load_or_build_graph. Invalid inputs are now rejected in O(1).

## Verification

```
$ chainsaw trace tsconfig.json
error: '.../tsconfig.json' is not a source file (expected .ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts)

$ chainsaw trace src/
error: '.../src' is a directory, not a source file
```

Both return instantly. All 97 existing tests pass, no performance
regression on valid entry files.

Closes #28