### PR TITLE
chore: drop MSRV checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = ["xtask", "stats"]
 name = "chainsaw-cli"
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.91"
 description = "Trace transitive import weight in TypeScript and Python codebases"
 license = "MIT"
 repository = "https://github.com/rocketman-code/chainsaw"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,6 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Remove `rust-version` from Cargo.toml
- Remove MSRV job from CI workflow
- Remove `msrv` from xtask Cargo.toml features

Chainsaw is an end-user CLI tool, not a library. MSRV enforcement adds CI maintenance overhead with no downstream value.

## Test plan
- [x] `cargo xtask check` passes