### PR TITLE
fix(ci): skip checks when only non-code files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
               - '**/Cargo.toml'
               - '**/Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.cargo/config.toml'
               - '.github/workflows/ci.yml'
+              - 'perf.toml'
 
   test:
     needs: changes


### PR DESCRIPTION
## Summary
- Add change detection: test, clippy, fmt, and perf only run when code files change (`.rs`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, CI workflow)
- Add `build` gate job that always runs for branch protection -- passes immediately on docs-only PRs, checks all job results otherwise
- Remove `msrv` job (CLI tool, not a library)

Docs-only PRs like #84 no longer burn CI minutes compiling Rust.

## Test plan
- [x] This PR itself modifies only `.yml` -- the `build` gate job should pass without running test/clippy/fmt/perf
- [ ] A code-touching PR should still run the full suite