### PR TITLE
chore: unify MSRV and toolchain pin to 1.91

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.91.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.91.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.91.0
         with:
           components: rustfmt
       - run: cargo fmt --check
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.91.0
       - uses: Swatinem/rust-cache@v2
 
       - uses: actions/cache@v4
@@ -130,6 +130,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.91.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo publish --dry-run

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy"]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1091,7 +1091,10 @@ mod tests {
         TraceSnapshot {
             entry: entry.to_string(),
             static_weight,
-            packages: packages.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
+            packages: packages
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), *v))
+                .collect(),
             dynamic_weight: 0,
             dynamic_packages: HashMap::new(),
         }
@@ -1107,11 +1110,14 @@ mod tests {
         TraceSnapshot {
             entry: entry.to_string(),
             static_weight,
-            packages: packages.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
+            packages: packages
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), *v))
+                .collect(),
             dynamic_weight,
             dynamic_packages: dynamic_packages
                 .iter()
-                .map(|(k, v)| (k.to_string(), *v))
+                .map(|(k, v)| ((*k).to_string(), *v))
                 .collect(),
         }
     }

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -2,5 +2,5 @@
 name = "stats"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 publish = false

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Unify `rust-version` across all workspace members to 1.91 (true MSRV, driven by OXC 0.113)
- Pin dev toolchain to 1.91 (was 1.93) so we develop on the same version we claim to support
- Fix `inefficient_to_string` clippy lint surfaced by 1.91 clippy

Replaces #85. The original approach (drop MSRV entirely) doesn't hold since v0.3.0 introduces a Session API that makes chainsaw usable as a library. Instead, unify everything to match reality and catch compatibility issues at the source.

## Test plan
- [x] `cargo xtask check` passes on 1.91