### PR TITLE
fix(cache): preserve per-file unresolvable dynamic import details

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -402,6 +402,7 @@ fn register_benchmarks() -> Vec<Benchmark> {
             &result.graph,
             result.unresolved_specifiers,
             unresolvable_count,
+            result.unresolvable_dynamic,
         );
         benches.push(Benchmark {
             name: "cache_load_validate_ts",

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,7 +378,7 @@ fn print_build_status(loaded: &loader::LoadedGraph, start: Instant, sc: report::
     for w in &loaded.file_warnings {
         eprintln!("{} {w}", sc.warning("warning:"));
     }
-    if loaded.unresolvable_dynamic_count > 0 && !loaded.from_cache {
+    if loaded.unresolvable_dynamic_count > 0 {
         let count = loaded.unresolvable_dynamic_count;
         eprintln!(
             "{} {count} dynamic import{} with non-literal argument{} could not be traced:",
@@ -386,7 +386,9 @@ fn print_build_status(loaded: &loader::LoadedGraph, start: Instant, sc: report::
             if count == 1 { "" } else { "s" },
             if count == 1 { "" } else { "s" },
         );
-        for (path, file_count) in &loaded.unresolvable_dynamic_files {
+        let mut files = loaded.unresolvable_dynamic_files.clone();
+        files.sort_by(|a, b| a.0.cmp(&b.0));
+        for (path, file_count) in &files {
             let rel = report::relative_path(path, &loaded.root);
             eprintln!("  {rel} ({file_count})");
         }


### PR DESCRIPTION
## Summary
- Serialize per-file unresolvable dynamic import counts into CachedGraph so the warning displays identically on cold and cached runs
- Propagate per-file data through tier 1 hits, tier 1.5 incremental updates, and cold builds
- Remove `!loaded.from_cache` guard that suppressed per-file details on cache hits

Closes #80

## Test plan
- [x] `cargo xtask check` passes
- [x] New test: `graph_cache_preserves_per_file_unresolvable_dynamic` verifies roundtrip
- [x] Manual: wrangler cold run shows per-file warning, cached run now shows identical output