### PR TITLE
docs(readme): unify examples and document new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,24 @@
 Trace the transitive import weight of any TypeScript or Python entry point. Point it at a file, get back what gets pulled in at startup and how much code it costs.
 
 ```
-$ chainsaw trace src/cli/main.ts
+$ chainsaw trace src/index.ts
 
-src/cli/main.ts
-Static transitive weight: 17.7 MB (1870 modules)
-Dynamic-only weight: 16 KB (16 modules, not loaded at startup)
+src/index.ts
+Static transitive weight: 8.2 MB (2140 modules)
+Dynamic-only weight: 120 KB (34 modules, not loaded at startup)
 
 Heavy dependencies (static):
-  highlight.js                        1.4 MB  193 files
-    -> src/cli/main.ts -> ... -> cli-highlight -> highlight.js
+  undici                              1.1 MB  108 files
+    -> src/index.ts -> src/http/client.ts -> undici
+  date-fns                            619 KB  304 files
+    -> src/index.ts -> src/jobs/scheduler.ts -> date-fns
   zod                                 537 KB  76 files
-    -> src/cli/main.ts -> src/config/config.ts -> src/config/schema.ts -> zod
+    -> src/index.ts -> src/api/routes.ts -> src/api/validation.ts -> zod
 
 Modules (sorted by exclusive weight):
-  src/cli/main.ts                                            17.7 MB
-  src/commands/doctor.ts                                     17.7 MB
-  src/config/sessions/transcript.ts                          17.5 MB
+  src/generated/api-types.ts                                412 KB
+  src/i18n/locales.ts                                       238 KB
+  src/api/routes.ts                                         127 KB
   ...
 ```
 
@@ -39,38 +41,38 @@ cargo install chainsaw-cli
 Works the same way. Resolution matches `importlib` behavior -- source roots, virtualenv, `.pth` files, `sys.path` modifications, C extensions.
 
 ```
-$ chainsaw trace manage.py
+$ chainsaw trace app/main.py
 
-manage.py
+app/main.py
 Static transitive weight: 2.1 MB (608 modules)
 
 Heavy dependencies (static):
   botocore                            1.2 MB  340 files
-    -> manage.py -> ... -> boto3 -> botocore
+    -> app/main.py -> ... -> boto3 -> botocore
 ```
 
 ### Why is this package in my tree?
 
 ```
-$ chainsaw trace src/cli/main.ts --chain zod
+$ chainsaw trace src/index.ts --chain zod
 
 3 chains to "zod" (3 hops):
 
-  1. src/cli/main.ts -> src/config/config.ts -> src/config/schema.ts -> zod
-  2. src/cli/main.ts -> src/config/migrate.ts -> src/config/schema.ts -> zod
-  3. src/cli/main.ts -> src/config/validation.ts -> src/config/schema.ts -> zod
+  1. src/index.ts -> src/api/routes.ts -> src/api/validation.ts -> zod
+  2. src/index.ts -> src/api/middleware.ts -> src/api/validation.ts -> zod
+  3. src/index.ts -> src/config/env.ts -> src/api/validation.ts -> zod
 ```
 
 ### Where to cut
 
-All three chains pass through `src/config/schema.ts`. Chainsaw finds that:
+All three chains pass through `src/api/validation.ts`. Chainsaw finds that:
 
 ```
-$ chainsaw trace src/cli/main.ts --cut zod
+$ chainsaw trace src/index.ts --cut zod
 
 1 cut point to sever all 3 chains to "zod":
 
-  src/config/schema.ts                                    (breaks 3/3 chains)
+  src/api/validation.ts                                   (breaks 3/3 chains)
 ```
 
 Make that import dynamic and zod drops out of your startup path.
@@ -87,42 +89,60 @@ Each chain takes a different path — multiple fixes needed.
 Compare two entry points:
 
 ```
-$ chainsaw trace src/cli.ts --diff src/server.ts
+$ chainsaw trace src/index.ts --diff src/worker.ts
 
-Diff: src/cli.ts vs src/server.ts
+Diff: src/index.ts vs src/worker.ts
 
-  src/cli.ts                               793 KB
-  src/server.ts                            3.8 MB
-  Delta                                    +3.1 MB
+  src/index.ts                               8.2 MB
+  src/worker.ts                              2.4 MB
+  Delta                                      -5.8 MB
 
-Only in src/cli.ts:
-  - degit                                42 KB
-  - smol-toml                            28 KB
-Only in src/server.ts:
-  + undici                              1.1 MB
-  + workerd                             800 KB
-  + zod                                 537 KB
-Shared: 21 packages
+Only in src/index.ts:
+  - undici                              1.1 MB
+  - date-fns                            619 KB
+  - zod                                 537 KB
+Only in src/worker.ts:
+  + html-rewriter                        84 KB
+Shared: 12 packages
 ```
 
 Or save a snapshot and compare before/after:
 
 ```
-$ chainsaw trace src/cli/main.ts --save before.json
+$ chainsaw trace src/index.ts --save before.json
 # ... make changes ...
-$ chainsaw trace src/cli/main.ts --diff-from before.json
+$ chainsaw trace src/index.ts --diff-from before.json
 ```
 
 The `diff` subcommand compares two saved snapshots directly: `chainsaw diff before.json after.json`
 
+Compare against a git ref to see how weight changed over time:
+
+```
+$ chainsaw diff HEAD~10 --entry src/index.ts
+```
+
 In a monorepo, the diff target can be in a different package -- chainsaw builds a separate graph from that package's root automatically.
+
+### Interactive mode
+
+Run multiple queries against a cached graph without rebuilding:
+
+```
+$ chainsaw repl src/index.ts
+
+chainsaw> trace
+chainsaw> chain zod
+chainsaw> cut zod
+chainsaw> packages
+```
 
 ### CI gating
 
 ```
 $ chainsaw trace src/index.ts --max-weight 5MB --quiet --top 0 --top-modules 0
 
-error: static weight 36.3 MB exceeds threshold 5.0 MB
+error: static transitive weight 8.2 MB (2140 modules) exceeds --max-weight threshold 5.0 MB
 ```
 
 Exits non-zero when static weight exceeds the threshold. Accepts `5MB`, `500KB`, `100B`.


### PR DESCRIPTION
## Summary
- Thread all examples through one canonical codebase (src/index.ts) so the reader follows a single exploration journey instead of reorienting between different projects each section
- Document interactive mode (repl subcommand)
- Document git ref diffing

## Test plan
- [x] No code changes, docs only