### PR TITLE
docs(standards): add project standards directory

### DIFF
--- a/docs/standards/code.md
+++ b/docs/standards/code.md
@@ -1,0 +1,73 @@
+# Code
+
+## Rust Style
+
+- Edition 2024
+- `#![warn(clippy::pedantic)]` with targeted `#[allow(...)]` where justified
+- Idiomatic Rust: prefer stdlib patterns (iterators, windows, if-let chains, Result propagation with `?`) over manual indexing, `process::exit` (except at the CLI boundary in `main.rs`), or hand-rolled logic
+- No bash scripts in the project: use `cargo xtask` for Rust logic, `Justfile` for external tool orchestration
+
+## API Hygiene
+
+- All public types enforced Send + Sync + Unpin via compile-time `auto_trait_tests` in lib.rs
+- `#[non_exhaustive]` on public structs and enums (prevents external construction, allows future fields)
+- `publish = false` on internal workspace crates (`stats/`, `xtask/`)
+
+## Testing
+
+Tests co-located in source files via `#[cfg(test)]` modules, not in a separate `tests/` directory. Integration tests in `tests/` are the exception (e.g., `tests/perf_registry.rs`).
+
+Test helpers: `parse_ts()` / `parse_py()` for parser tests, `make_graph()` for query tests.
+
+### When to Test
+
+- ALWAYS test: silent/delayed failures (parsers, resolvers, query algorithms, cache invalidation, graph construction)
+- Test at boundaries: where a dependency could silently return something different
+- Test data transformations: where external data enters and gets transformed
+
+### When NOT to Test
+
+- Subjective design choices (help text wording, formatting preferences)
+- External library internals
+- Loud failures (code that crashes immediately and obviously)
+- Trivial delegation (just passing args to a well-tested dependency)
+
+### Special Categories
+
+- Conformance tests: `#[ignore]`, run manually with `PYTHON_PROJECT` env var
+- Auto-trait guards: compile-time, kept always
+- Infrastructure tests: perf registry, benchmark harness, xtask -- kept (broken tooling silently produces wrong measurements)
+
+## New Files
+
+Every new `.rs` file must be registered in `perf.toml` (with `benchmarks = []` if not perf-sensitive). An integration test enforces completeness.
+
+## Cache Version
+
+Bump `CACHE_VERSION` whenever the serialization format changes. This triggers automatic cache rebuild for all users.
+
+## Performance Infrastructure
+
+`perf.toml` maps source files to benchmarks. Pre-push hook runs `cargo xtask perf-validate` when perf-sensitive files change. The adaptive benchmark harness uses Welch t-test with early stopping.
+
+Manual benchmarks:
+
+```
+cargo bench --bench benchmarks         # raw benchmark run
+just bench-cold                        # hyperfine cold-start A/B
+just bench-all                         # cold + warm + edit scenarios
+```
+
+Performance workflow:
+1. Make your change
+2. `git commit` -- pre-commit hook runs `cargo xtask check`
+3. If perf-sensitive files changed: `cargo xtask perf-validate` to generate attestation (must run after commit -- the attestation includes the commit SHA)
+4. `git push` -- pre-push hook verifies attestation
+
+## CI
+
+Smart change detection via `dorny/paths-filter`: test, clippy, fmt, perf only run when code files change (.rs, Cargo.toml, Cargo.lock, rust-toolchain.toml, .cargo/config.toml, perf.toml, ci.yml). Docs-only PRs skip all compilation.
+
+Jobs: test (ubuntu + macos), clippy, fmt, perf (synthetic corpus micros), build (gate job, always runs). On tags: publish-check (`cargo publish --dry-run`).
+
+NOT in CI: cold-build I/O benchmarks (kernel-bound, noise on shared runners), conformance tests, `cargo publish` itself, full perf-validate.

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -1,0 +1,63 @@
+# Commits
+
+## Format
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): lowercase imperative description
+```
+
+## Types
+
+- `feat` -- new feature
+- `fix` -- bug fix
+- `refactor` -- code restructuring (no behavior change)
+- `test` -- tests only (no production code)
+- `docs` -- documentation
+- `chore` -- maintenance (deps, tooling, config)
+- `style` -- formatting (no logic change)
+- `perf` -- performance improvement (see [perf commit standard](#the-perf-commit-standard))
+
+## Scope
+
+The affected area in lowercase. Examples: `resolver`, `cache`, `cli`, `walker`, `parser`, `repl`, `xtask`, `cargo`, `ci`.
+
+## Granularity
+
+Many tightly scoped commits, one logical concern per commit. Never batch multiple concerns into a monolith.
+
+Example: adding a new feature with tests, updating the registry, and adding scaffolding = 3 separate commits, not 1 (feature + tests go together per the rule below).
+
+## The perf Commit Standard
+
+A `perf(scope):` commit on main is a claim of measured improvement. It must meet this bar:
+
+1. PR includes benchmark evidence (before/after numbers, which benchmarks, which targets)
+2. At least one benchmark shows statistically significant improvement (Welch t-test via the adaptive harness)
+3. No benchmark regresses beyond noise
+
+If the improvement is within noise (not statistically significant), label it `refactor`, not `perf`. A real structural improvement that happens to not move the needle is still valuable -- it's just not a performance commit.
+
+If a change improves one target but regresses another, don't commit it. The optimization isn't understood well enough. Profile further or revert.
+
+### Adding benchmarks alongside optimizations
+
+When optimizing a code path with no existing benchmark, add the benchmark in the same PR. This is TDD for performance: the new benchmark both proves the improvement and guards against future regressions on that code path. The PR must still show before/after evidence -- run the new benchmark against both the base branch and the optimized branch to produce the comparison.
+
+## Fix + Tests in Same Commit
+
+Implementation and its tests go in the same commit. Never split a fix from the test that validates it. Standalone test additions (new edge cases, coverage improvements unrelated to a specific change) can be separate `test(scope)` commits.
+
+## Examples
+
+```
+feat(resolver): add namespace package support
+fix(cache): handle stale lockfile sentinel
+test(parser): add edge case for re-exports
+refactor(walker): extract work queue into separate function
+perf(vfs): reuse file handles to reduce syscalls
+chore(cargo): bump version to 0.3.0
+docs(contributing): add branching and merge policy
+style(error): apply consistent quote style
+```

--- a/docs/standards/issues.md
+++ b/docs/standards/issues.md
@@ -1,0 +1,54 @@
+# Issues
+
+## Labels
+
+Two dimensions. Every issue gets exactly one of each.
+
+### Category (what kind of work)
+
+- `bug` -- something isn't working as expected
+- `enhancement` -- new feature or improvement
+- `ux` -- user experience improvement (same priority model as enhancement)
+- `research` -- investigation spike (output is a decision, not code)
+
+### Priority (how urgent)
+
+- `P1` (red) -- critical. Broken functionality, data loss, blocking a release, or actively hurting users. Drop everything.
+- `P2` (yellow) -- medium. Important, planned for the next milestone. This is the active work queue.
+- `P3` (green) -- low. Nice to have, backlog. Gets done when relevant or someone's bored.
+
+## Issue Types
+
+- `Bug` -- fix it, patch release (0.x.1). Category label: `bug`.
+- `Enhancement` -- plan it, milestone it, minor release (0.x.0). Category label: `enhancement`.
+- `Research spike` -- timebox the investigation. Output is a decision, not code. Close with a conclusion in the issue comments, open follow-up issues if warranted. Category label: `research`.
+- `UX improvement` -- same lifecycle as enhancement. Category label: `ux`.
+
+## Triage
+
+Every new issue gets triaged before work starts:
+
+1. Read the issue, understand the scope
+2. Assign category label (`bug`, `enhancement`, `ux`, or `research`)
+3. Assign priority label (`P1`, `P2`, or `P3`)
+4. Optionally assign to a milestone (if it belongs to a planned release)
+
+Triage format (when processing multiple issues):
+
+```
+| # | Title | Category | Priority | Rationale |
+```
+
+## Issue Templates
+
+- Bug report (`bug_report.yml`): auto-labels `bug`. Priority added manually during triage.
+- Feature request (`feature_request.yml`): auto-labels `enhancement`. Priority added manually during triage.
+
+## Milestones
+
+Milestones = releases. Each planned minor version gets a GitHub milestone (e.g., "v0.4.0"). Issues assigned to milestones indicate planned scope for that release.
+
+- P2 issues are typically assigned to the next milestone
+- P3 issues go to Backlog milestone or no milestone
+- Close milestone after the release is published
+- Check milestones: `gh api repos/rocketman-code/chainsaw/milestones`

--- a/docs/standards/pull-requests.md
+++ b/docs/standards/pull-requests.md
@@ -1,0 +1,84 @@
+# Pull Requests
+
+## All Changes Go Through PRs
+
+No exceptions, no size threshold. Even a one-line typo fix gets a PR. This gives:
+- CI gate (tests, clippy, fmt run automatically)
+- Linkable paper trail
+- Accountability for every change on main
+
+## Branch Naming
+
+`type/slug` where type matches conventional commit types:
+
+```
+feat/namespace-packages
+fix/cache-invalidation
+refactor/walker-pipeline
+docs/contributing
+test/resolver-edge-cases
+chore/drop-msrv
+perf/mtime-capture
+```
+
+## PR Scoping
+
+One `type(scope)` per PR. If you can't describe the PR with a single conventional commit prefix, split it into multiple PRs. A PR can contain multiple commits, but they should all serve the same `type(scope)`.
+
+Examples:
+- `fix(cli): improve error messages` -- one PR even if it's 6 commits fixing different error messages
+- `feat(xtask): add check subcommand` -- one PR for the new subcommand
+- A branch with both a new feature and unrelated doc updates -- split into two PRs
+
+## Push Early
+
+Always push feature branches to origin after the first commit. An unpushed branch is an unrecoverable branch -- if it gets deleted locally or garbage collected, the code is gone. A draft PR costs nothing and creates a paper trail.
+
+```
+git push -u origin feat/my-feature
+gh pr create --draft
+```
+
+The pre-commit hook warns when it detects commits accumulating on a branch with no remote tracking ref. Don't ignore this warning.
+
+## Merge Strategy
+
+Rebase merge only. Linear history, individual commits preserved on main. No squash merge (destroys granular commit history). No merge commits (non-linear history).
+
+How to merge:
+- CLI: `gh pr merge <number> --rebase` (always pass `--rebase` explicitly)
+- UI: GitHub's "Rebase and merge" button
+
+Never use `gh pr merge` without `--rebase` -- the default creates a merge commit.
+
+## PR Iteration
+
+During review: add new commits on top. Never amend or force-push during review -- it destroys review context and reviewers can't see what changed between reviews. Fixer commits are fine during iteration -- they get cleaned up before merge.
+
+## Pre-Merge Cleanup
+
+Only required when the branch has iteration noise (fixer commits, review responses, partial work). If the branch already has clean, logically scoped commits, skip the cleanup and merge directly.
+
+When cleanup is needed:
+
+1. Soft reset to the base branch: `git reset --soft $(git merge-base HEAD main)`
+2. Re-commit by logical concern -- tightly scoped, one concern per commit
+3. Force push the clean history to the feature branch
+4. Then merge
+
+Force pushing to feature branches is only allowed during this cleanup step, never during active review.
+
+Main gets granular, clean commits. The PR branch absorbs the iteration mess.
+
+## Branch Protection (enforced on GitHub)
+
+- PRs required to merge into main
+- CI must pass before merge
+- No force pushes to main
+- Linear history required
+
+## PR Content
+
+Summary + test plan. Checklist items:
+- `cargo xtask check` passes (fmt + clippy + test)
+- If perf-sensitive files changed: `cargo xtask perf-validate` passes

--- a/docs/standards/releases.md
+++ b/docs/standards/releases.md
@@ -1,0 +1,49 @@
+# Releases
+
+## Versioning
+
+Pre-1.0 semver (0.x.y):
+- Minor bump (0.x.0) for new features
+- Patch bump (0.x.1) for bug fixes
+- Breaking changes allowed in minor bumps (pre-1.0 semver) but treated as a last resort
+- 1.0 = "the CLI interface is stable, your scripts won't break"
+
+## Compatibility Surface (breaking = version bump)
+
+- CLI flags and subcommands (renaming/removing breaks scripts)
+- Exit codes (`--max-weight` returns 1 on failure, CI depends on this)
+- JSON output schema (people pipe `--json` to jq in CI)
+- Snapshot file format (people save these and compare days/weeks later)
+
+## NOT Compatibility Concerns
+
+- Cache format -- transparent, auto-rebuilds on mismatch, CACHE_VERSION bumps are free
+- Internal lib API -- documented as unstable in crate-level docs
+- Human-readable output wording -- if someone parses non-JSON text output, that's on them
+- Performance -- faster is never breaking, slower is a regression but not a semver event
+
+## Release Cadence
+
+Batch related changes, release when there's a meaningful set of user-facing changes. No version bump per PR.
+
+## Release Checklist
+
+1. All milestone issues closed
+2. `cargo test --workspace` passes
+3. `cargo clippy --workspace --all-targets -- -D warnings` clean
+4. `cargo publish --dry-run` clean
+5. Perf validation passes locally (`cargo xtask perf-validate`)
+6. Bump version in `Cargo.toml` + run `cargo generate-lockfile`
+7. Commit: `chore(cargo): bump version to 0.x.y`
+8. Tag: `git tag v0.x.y`
+9. Push: `git push && git push --tags`
+10. Publish: `cargo publish`
+11. Close the milestone on GitHub
+
+## Git Tags
+
+Format: `v0.x.y` (e.g., `v0.1.0`, `v0.2.0`, `v0.3.0`). Tag the version bump commit.
+
+## Changelog
+
+No CHANGELOG.md file. Commit messages use conventional commits. GitHub releases with auto-generated notes from tags are sufficient.


### PR DESCRIPTION
## Summary

- Add `docs/standards/` with 5 focused files: issues, pull requests, commits, releases, code
- Consolidate scattered standards from CONTRIBUTING.md and project documentation
- Rewrite CONTRIBUTING.md as an onboarding guide with links to standards files
- Formalize implicit standards (perf commit bar, research label, pre-merge cleanup)

Also done outside this branch (not in diff):
- Created `research` label, deleted 7 unused GitHub default labels
- Reclassified #79 and #83 from `enhancement` to `research`

## Test Plan

- [x] `cargo test --workspace` passes (289 tests, 0 failures)
- [x] All 16 open issues verified: exactly 1 category + 1 priority each
- [x] 7 GitHub labels remaining: bug, enhancement, ux, research, P1, P2, P3