### PR TITLE
feat(repl): add session settings and per-command inline flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ mod auto_trait_tests {
         is_normal::<crate::lang::ProjectKind>();
         is_normal::<crate::git::DiffArg>();
         is_normal::<crate::repl::Command>();
+        is_normal::<crate::repl::ReplSettings>();
+        is_normal::<crate::repl::CommandOptions>();
         is_normal::<crate::report::TraceReport>();
         is_normal::<crate::report::ChainReport>();
         is_normal::<crate::report::CutReport>();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,8 +1,8 @@
 //! REPL command parser and interactive loop.
 //!
-//! The command parser is deliberately simple: one word command, optional
-//! argument string. No shell-style quoting or flags — the REPL is an
-//! interactive explorer, not a second CLI.
+//! Commands accept optional inline flags (`--include-dynamic`, `--top N`, etc.)
+//! that override session-level settings for a single invocation. Use
+//! `set`/`unset`/`show` to manage persistent session settings.
 
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -19,26 +19,130 @@ use crate::query::{self, ChainTarget};
 use crate::report::{self, StderrColor};
 use crate::session::Session;
 
+/// Session-level settings that persist across REPL commands.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ReplSettings {
+    pub include_dynamic: bool,
+    pub top: i32,
+    pub top_modules: i32,
+    pub ignore: Vec<String>,
+}
+
+impl Default for ReplSettings {
+    fn default() -> Self {
+        Self {
+            include_dynamic: false,
+            top: report::DEFAULT_TOP,
+            top_modules: report::DEFAULT_TOP_MODULES,
+            ignore: Vec::new(),
+        }
+    }
+}
+
+/// Per-command option overrides. `None` means "use session default".
+#[non_exhaustive]
+#[derive(Default, Debug)]
+pub struct CommandOptions {
+    pub include_dynamic: Option<bool>,
+    pub top: Option<i32>,
+    pub top_modules: Option<i32>,
+    pub ignore: Option<Vec<String>>,
+}
+
+impl CommandOptions {
+    /// Resolve per-command overrides against session settings.
+    /// Returns `(TraceOptions, top_modules)`.
+    pub fn resolve(&self, settings: &ReplSettings) -> (query::TraceOptions, i32) {
+        let opts = query::TraceOptions {
+            include_dynamic: self.include_dynamic.unwrap_or(settings.include_dynamic),
+            top_n: self.top.unwrap_or(settings.top),
+            ignore: self
+                .ignore
+                .clone()
+                .unwrap_or_else(|| settings.ignore.clone()),
+        };
+        let top_modules = self.top_modules.unwrap_or(settings.top_modules);
+        (opts, top_modules)
+    }
+}
+
+/// Extract known `--flag` tokens from an argument list.
+///
+/// Returns `(CommandOptions, positional_arg)`. The positional argument is
+/// the first non-flag token that isn't consumed as a flag value. `--ignore`
+/// consumes all subsequent non-flag tokens until the next `--` flag or end
+/// of input, so it must appear after the positional arg or be the last flag.
+fn parse_flags(tokens: &[&str]) -> (CommandOptions, String) {
+    let mut opts = CommandOptions::default();
+    let mut positional = Vec::new();
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens[i] {
+            "--include-dynamic" => opts.include_dynamic = Some(true),
+            "--no-include-dynamic" => opts.include_dynamic = Some(false),
+            "--top" => {
+                if let Some(val) = tokens.get(i + 1).and_then(|v| v.parse().ok()) {
+                    i += 1;
+                    if val >= -1 {
+                        opts.top = Some(val);
+                    }
+                }
+            }
+            "--top-modules" => {
+                if let Some(val) = tokens.get(i + 1).and_then(|v| v.parse().ok()) {
+                    i += 1;
+                    if val >= -1 {
+                        opts.top_modules = Some(val);
+                    }
+                }
+            }
+            "--ignore" => {
+                let mut pkgs = Vec::new();
+                i += 1;
+                while i < tokens.len() && !tokens[i].starts_with("--") {
+                    pkgs.push(tokens[i].to_string());
+                    i += 1;
+                }
+                if !pkgs.is_empty() {
+                    opts.ignore = Some(pkgs);
+                }
+                continue; // i already advanced past consumed tokens
+            }
+            other => positional.push(other),
+        }
+        i += 1;
+    }
+    (opts, positional.join(" "))
+}
+
 /// A parsed REPL command.
+#[derive(Debug)]
 pub enum Command {
     /// Trace transitive weight (optionally from a different file).
-    Trace(Option<String>),
+    Trace(Option<String>, CommandOptions),
     /// Switch the session entry point.
     Entry(String),
     /// Show import chains to a target.
-    Chain(String),
+    Chain(String, CommandOptions),
     /// Show optimal cut points for a target.
-    Cut(String),
+    Cut(String, CommandOptions),
     /// Diff against another entry point.
-    Diff(String),
+    Diff(String, CommandOptions),
     /// List all third-party packages.
-    Packages,
+    Packages(CommandOptions),
     /// List direct imports of a file.
     Imports(String),
     /// List files that import a given file.
     Importers(String),
     /// Show package info by name.
     Info(String),
+    /// Set a session option.
+    Set(String),
+    /// Reset a session option to its default.
+    Unset(String),
+    /// Display current session settings.
+    Show,
     /// Print help text.
     Help,
     /// Exit the REPL.
@@ -50,8 +154,17 @@ pub enum Command {
 impl Command {
     /// Parse a single line of user input into a command.
     pub fn parse(line: &str) -> Self {
-        /// Extract a non-empty argument or return an error message.
-        fn require(arg: Option<&str>, msg: &str) -> Result<String, String> {
+        /// Extract a non-empty positional or return an error message.
+        fn require_positional(positional: &str, msg: &str) -> Result<String, String> {
+            if positional.is_empty() {
+                Err(msg.to_string())
+            } else {
+                Ok(positional.to_string())
+            }
+        }
+
+        /// Require a non-empty raw argument string.
+        fn require_arg(arg: Option<&str>, msg: &str) -> Result<String, String> {
             match arg {
                 Some(a) if !a.is_empty() => Ok(a.to_string()),
                 _ => Err(msg.to_string()),
@@ -66,37 +179,71 @@ impl Command {
             .split_once(' ')
             .map_or((line, None), |(c, a)| (c, Some(a.trim())));
 
+        // Tokenize the argument string for commands that accept flags.
+        let tokens: Vec<&str> = arg
+            .map(|a| a.split_whitespace().collect())
+            .unwrap_or_default();
+
         match cmd {
-            "trace" => Self::Trace(arg.map(String::from)),
-            "entry" => match require(arg, "entry requires a file argument") {
+            "trace" => {
+                let (opts, positional) = parse_flags(&tokens);
+                let file = if positional.is_empty() {
+                    None
+                } else {
+                    Some(positional)
+                };
+                Self::Trace(file, opts)
+            }
+            "chain" => {
+                let (opts, positional) = parse_flags(&tokens);
+                match require_positional(&positional, "chain requires a target argument") {
+                    Ok(a) => Self::Chain(a, opts),
+                    Err(e) => Self::Unknown(e),
+                }
+            }
+            "cut" => {
+                let (opts, positional) = parse_flags(&tokens);
+                match require_positional(&positional, "cut requires a target argument") {
+                    Ok(a) => Self::Cut(a, opts),
+                    Err(e) => Self::Unknown(e),
+                }
+            }
+            "diff" => {
+                let (opts, positional) = parse_flags(&tokens);
+                match require_positional(&positional, "diff requires a file argument") {
+                    Ok(a) => Self::Diff(a, opts),
+                    Err(e) => Self::Unknown(e),
+                }
+            }
+            "packages" => {
+                let (opts, _) = parse_flags(&tokens);
+                Self::Packages(opts)
+            }
+            "entry" => match require_arg(arg, "entry requires a file argument") {
                 Ok(a) => Self::Entry(a),
                 Err(e) => Self::Unknown(e),
             },
-            "chain" => match require(arg, "chain requires a target argument") {
-                Ok(a) => Self::Chain(a),
-                Err(e) => Self::Unknown(e),
-            },
-            "cut" => match require(arg, "cut requires a target argument") {
-                Ok(a) => Self::Cut(a),
-                Err(e) => Self::Unknown(e),
-            },
-            "diff" => match require(arg, "diff requires a file argument") {
-                Ok(a) => Self::Diff(a),
-                Err(e) => Self::Unknown(e),
-            },
-            "imports" => match require(arg, "imports requires a file argument") {
+            "imports" => match require_arg(arg, "imports requires a file argument") {
                 Ok(a) => Self::Imports(a),
                 Err(e) => Self::Unknown(e),
             },
-            "importers" => match require(arg, "importers requires a file argument") {
+            "importers" => match require_arg(arg, "importers requires a file argument") {
                 Ok(a) => Self::Importers(a),
                 Err(e) => Self::Unknown(e),
             },
-            "info" => match require(arg, "info requires a package name") {
+            "info" => match require_arg(arg, "info requires a package name") {
                 Ok(a) => Self::Info(a),
                 Err(e) => Self::Unknown(e),
             },
-            "packages" => Self::Packages,
+            "set" => match require_arg(arg, "set requires an option name") {
+                Ok(a) => Self::Set(a),
+                Err(e) => Self::Unknown(e),
+            },
+            "unset" => match require_arg(arg, "unset requires an option name") {
+                Ok(a) => Self::Unset(a),
+                Err(e) => Self::Unknown(e),
+            },
+            "show" => Self::Show,
             "help" | "?" => Self::Help,
             "quit" | "exit" => Self::Quit,
             _ => Self::Unknown(format!("unknown command: {cmd}")),
@@ -106,18 +253,21 @@ impl Command {
 
 /// All command names, for tab completion.
 pub const COMMAND_NAMES: &[&str] = &[
-    "trace",
-    "entry",
     "chain",
     "cut",
     "diff",
-    "packages",
-    "imports",
-    "importers",
-    "info",
-    "help",
-    "quit",
+    "entry",
     "exit",
+    "help",
+    "importers",
+    "imports",
+    "info",
+    "packages",
+    "quit",
+    "set",
+    "show",
+    "trace",
+    "unset",
 ];
 
 // ---------------------------------------------------------------------------
@@ -140,6 +290,9 @@ fn sorted_prefix_matches<'a>(sorted: &'a [String], prefix: &str, limit: usize) -
         .map(String::as_str)
         .collect()
 }
+
+/// Option names for `set`/`unset` tab completion (sorted).
+const OPTION_NAMES: &[&str] = &["dynamic", "ignore", "include-dynamic", "top", "top-modules"];
 
 struct ChainsawHelper {
     file_paths: Vec<String>,
@@ -225,6 +378,15 @@ impl Completer for ChainsawHelper {
                     })
                     .collect()
             }
+            "set" | "unset" => OPTION_NAMES
+                .iter()
+                .filter(|c| c.starts_with(partial))
+                .take(MAX_COMPLETIONS)
+                .map(|&c| Pair {
+                    display: c.to_string(),
+                    replacement: c.to_string(),
+                })
+                .collect(),
             _ => return Ok((start, vec![])),
         };
 
@@ -281,6 +443,7 @@ pub fn run(entry: &Path, no_color: bool, sc: StderrColor) -> Result<(), Error> {
         let _ = rl.load_history(path);
     }
 
+    let mut settings = ReplSettings::default();
     let prompt = format!("{}> ", sc.status("chainsaw"));
 
     loop {
@@ -317,15 +480,28 @@ pub fn run(entry: &Path, no_color: bool, sc: StderrColor) -> Result<(), Error> {
         rl.add_history_entry(trimmed).ok();
 
         match Command::parse(trimmed) {
-            Command::Trace(file) => dispatch_trace(&mut session, file.as_deref(), color, sc),
+            Command::Trace(file, ref opts) => {
+                dispatch_trace(&mut session, file.as_deref(), opts, &settings, color, sc);
+            }
             Command::Entry(path) => dispatch_entry(&mut session, &path, sc),
-            Command::Chain(target) => dispatch_chain(&session, &target, color, sc),
-            Command::Cut(target) => dispatch_cut(&mut session, &target, color, sc),
-            Command::Diff(path) => dispatch_diff(&mut session, &path, color, sc),
-            Command::Packages => dispatch_packages(&session, color),
+            Command::Chain(target, ref opts) => {
+                dispatch_chain(&session, &target, opts, &settings, color, sc);
+            }
+            Command::Cut(target, ref opts) => {
+                dispatch_cut(&mut session, &target, opts, &settings, color, sc);
+            }
+            Command::Diff(path, ref opts) => {
+                dispatch_diff(&mut session, &path, opts, &settings, color, sc);
+            }
+            Command::Packages(ref opts) => {
+                dispatch_packages(&session, opts, &settings, color);
+            }
             Command::Imports(path) => dispatch_imports(&session, &path, sc),
             Command::Importers(path) => dispatch_importers(&session, &path, sc),
             Command::Info(name) => dispatch_info(&session, &name, sc),
+            Command::Set(arg) => dispatch_set(&mut settings, &arg, sc),
+            Command::Unset(arg) => dispatch_unset(&mut settings, &arg, sc),
+            Command::Show => dispatch_show(&settings),
             Command::Help => print_help(),
             Command::Quit => break,
             Command::Unknown(msg) => eprintln!("{} {msg}", sc.error("error:")),
@@ -351,10 +527,17 @@ fn history_file() -> Option<PathBuf> {
 // Command dispatch
 // ---------------------------------------------------------------------------
 
-fn dispatch_trace(session: &mut Session, file: Option<&str>, color: bool, sc: StderrColor) {
-    let opts = query::TraceOptions::default();
+fn dispatch_trace(
+    session: &mut Session,
+    file: Option<&str>,
+    opts: &CommandOptions,
+    settings: &ReplSettings,
+    color: bool,
+    sc: StderrColor,
+) {
+    let (trace_opts, top_modules) = opts.resolve(settings);
     let report = if let Some(f) = file {
-        match session.trace_from_report(Path::new(f), &opts, report::DEFAULT_TOP_MODULES) {
+        match session.trace_from_report(Path::new(f), &trace_opts, top_modules) {
             Ok((r, _)) => r,
             Err(e) => {
                 eprintln!("{} {e}", sc.error("error:"));
@@ -362,7 +545,7 @@ fn dispatch_trace(session: &mut Session, file: Option<&str>, color: bool, sc: St
             }
         }
     } else {
-        session.trace_report(&opts, report::DEFAULT_TOP_MODULES)
+        session.trace_report(&trace_opts, top_modules)
     };
     print!("{}", report.to_terminal(color));
 }
@@ -376,36 +559,65 @@ fn dispatch_entry(session: &mut Session, path: &str, sc: StderrColor) {
     eprintln!("{} entry point is now {rel}", sc.status("Switched:"));
 }
 
-fn dispatch_chain(session: &Session, target: &str, color: bool, sc: StderrColor) {
+fn dispatch_chain(
+    session: &Session,
+    target: &str,
+    opts: &CommandOptions,
+    settings: &ReplSettings,
+    color: bool,
+    sc: StderrColor,
+) {
     let resolved = session.resolve_target(target);
     if resolved.target == ChainTarget::Module(session.entry_id()) {
         eprintln!("{} target is the entry point itself", sc.error("error:"));
         return;
     }
-    let report = session.chain_report(target, false);
+    let (trace_opts, _) = opts.resolve(settings);
+    let report = session.chain_report(target, trace_opts.include_dynamic);
     print!("{}", report.to_terminal(color));
 }
 
-fn dispatch_cut(session: &mut Session, target: &str, color: bool, sc: StderrColor) {
+fn dispatch_cut(
+    session: &mut Session,
+    target: &str,
+    opts: &CommandOptions,
+    settings: &ReplSettings,
+    color: bool,
+    sc: StderrColor,
+) {
     let resolved = session.resolve_target(target);
     if resolved.target == ChainTarget::Module(session.entry_id()) {
         eprintln!("{} target is the entry point itself", sc.error("error:"));
         return;
     }
-    let report = session.cut_report(target, report::DEFAULT_TOP, false);
+    let (trace_opts, _) = opts.resolve(settings);
+    let report = session.cut_report(target, trace_opts.top_n, trace_opts.include_dynamic);
     print!("{}", report.to_terminal(color));
 }
 
-fn dispatch_diff(session: &mut Session, path: &str, color: bool, sc: StderrColor) {
-    let opts = query::TraceOptions::default();
-    match session.diff_report(Path::new(path), &opts, report::DEFAULT_TOP) {
+fn dispatch_diff(
+    session: &mut Session,
+    path: &str,
+    opts: &CommandOptions,
+    settings: &ReplSettings,
+    color: bool,
+    sc: StderrColor,
+) {
+    let (trace_opts, _) = opts.resolve(settings);
+    match session.diff_report(Path::new(path), &trace_opts, trace_opts.top_n) {
         Ok(report) => print!("{}", report.to_terminal(color)),
         Err(e) => eprintln!("{} {e}", sc.error("error:")),
     }
 }
 
-fn dispatch_packages(session: &Session, color: bool) {
-    let report = session.packages_report(report::DEFAULT_TOP);
+fn dispatch_packages(
+    session: &Session,
+    opts: &CommandOptions,
+    settings: &ReplSettings,
+    color: bool,
+) {
+    let top = opts.top.unwrap_or(settings.top);
+    let report = session.packages_report(top);
     print!("{}", report.to_terminal(color));
 }
 
@@ -465,6 +677,124 @@ fn dispatch_info(session: &Session, name: &str, sc: StderrColor) {
     }
 }
 
+fn dispatch_set(settings: &mut ReplSettings, arg: &str, sc: StderrColor) {
+    let mut parts = arg.split_whitespace();
+    let Some(key) = parts.next() else {
+        eprintln!("{} set requires an option name", sc.error("error:"));
+        return;
+    };
+    match key {
+        "dynamic" | "include-dynamic" => {
+            let value = match parts.next() {
+                Some("true") => true,
+                Some("false") => false,
+                None => !settings.include_dynamic, // toggle
+                Some(v) => {
+                    eprintln!(
+                        "{} invalid value '{v}' for dynamic (expected true/false)",
+                        sc.error("error:")
+                    );
+                    return;
+                }
+            };
+            settings.include_dynamic = value;
+            eprintln!("{} dynamic = {value}", sc.status("Set:"));
+        }
+        "top" => {
+            let Some(val) = parts.next().and_then(|v| v.parse::<i32>().ok()) else {
+                eprintln!("{} top requires a number", sc.error("error:"));
+                return;
+            };
+            if val < -1 {
+                eprintln!(
+                    "{} invalid value {val} for top: must be -1 (all) or 0+",
+                    sc.error("error:")
+                );
+                return;
+            }
+            settings.top = val;
+            eprintln!("{} top = {val}", sc.status("Set:"));
+        }
+        "top-modules" => {
+            let Some(val) = parts.next().and_then(|v| v.parse::<i32>().ok()) else {
+                eprintln!("{} top-modules requires a number", sc.error("error:"));
+                return;
+            };
+            if val < -1 {
+                eprintln!(
+                    "{} invalid value {val} for top-modules: must be -1 (all) or 0+",
+                    sc.error("error:")
+                );
+                return;
+            }
+            settings.top_modules = val;
+            eprintln!("{} top-modules = {val}", sc.status("Set:"));
+        }
+        "ignore" => {
+            let pkgs: Vec<String> = parts.map(String::from).collect();
+            if pkgs.is_empty() {
+                eprintln!(
+                    "{} ignore requires one or more package names",
+                    sc.error("error:")
+                );
+                return;
+            }
+            eprintln!("{} ignore = [{}]", sc.status("Set:"), pkgs.join(", "));
+            settings.ignore = pkgs;
+        }
+        _ => eprintln!(
+            "{} unknown option '{key}' (try: dynamic, top, top-modules, ignore)",
+            sc.error("error:")
+        ),
+    }
+}
+
+fn dispatch_unset(settings: &mut ReplSettings, key: &str, sc: StderrColor) {
+    let key = key.trim();
+    match key {
+        "dynamic" | "include-dynamic" => {
+            settings.include_dynamic = false;
+            eprintln!("{} dynamic reset to false", sc.status("Unset:"));
+        }
+        "top" => {
+            settings.top = report::DEFAULT_TOP;
+            eprintln!(
+                "{} top reset to {}",
+                sc.status("Unset:"),
+                report::DEFAULT_TOP
+            );
+        }
+        "top-modules" => {
+            settings.top_modules = report::DEFAULT_TOP_MODULES;
+            eprintln!(
+                "{} top-modules reset to {}",
+                sc.status("Unset:"),
+                report::DEFAULT_TOP_MODULES
+            );
+        }
+        "ignore" => {
+            settings.ignore.clear();
+            eprintln!("{} ignore cleared", sc.status("Unset:"));
+        }
+        _ => eprintln!(
+            "{} unknown option '{key}' (try: dynamic, top, top-modules, ignore)",
+            sc.error("error:")
+        ),
+    }
+}
+
+fn dispatch_show(settings: &ReplSettings) {
+    println!("Settings:");
+    println!("  dynamic     = {}", settings.include_dynamic);
+    println!("  top         = {}", settings.top);
+    println!("  top-modules = {}", settings.top_modules);
+    if settings.ignore.is_empty() {
+        println!("  ignore      = (none)");
+    } else {
+        println!("  ignore      = [{}]", settings.ignore.join(", "));
+    }
+}
+
 fn print_help() {
     println!("Commands:");
     println!("  trace [file]       Trace from entry point (or specified file)");
@@ -476,8 +806,17 @@ fn print_help() {
     println!("  imports <file>     Show what a file imports");
     println!("  importers <file>   Show what imports a file");
     println!("  info <package>     Show package details");
+    println!("  set <opt> [val]    Set a session option (omit val to toggle booleans)");
+    println!("  unset <opt>        Reset an option to its default");
+    println!("  show               Display current settings");
     println!("  help               Show this help");
     println!("  quit               Exit");
+    println!();
+    println!("Inline flags (override session settings for one command):");
+    println!("  --include-dynamic / --no-include-dynamic    Include/exclude dynamic imports");
+    println!("  --top N                     Limit heavy deps / packages shown");
+    println!("  --top-modules N             Limit modules by exclusive weight");
+    println!("  --ignore pkg1 pkg2 ...      Exclude packages from heavy deps");
 }
 
 #[cfg(test)]
@@ -630,19 +969,19 @@ mod tests {
 
     #[test]
     fn parse_trace_no_arg() {
-        assert!(matches!(Command::parse("trace"), Command::Trace(None)));
+        assert!(matches!(Command::parse("trace"), Command::Trace(None, _)));
     }
 
     #[test]
     fn parse_trace_with_file() {
         assert!(
-            matches!(Command::parse("trace src/index.ts"), Command::Trace(Some(ref f)) if f == "src/index.ts")
+            matches!(Command::parse("trace src/index.ts"), Command::Trace(Some(ref f), _) if f == "src/index.ts")
         );
     }
 
     #[test]
     fn parse_chain() {
-        assert!(matches!(Command::parse("chain zod"), Command::Chain(ref t) if t == "zod"));
+        assert!(matches!(Command::parse("chain zod"), Command::Chain(ref t, _) if t == "zod"));
     }
 
     #[test]
@@ -654,7 +993,7 @@ mod tests {
 
     #[test]
     fn parse_packages() {
-        assert!(matches!(Command::parse("packages"), Command::Packages));
+        assert!(matches!(Command::parse("packages"), Command::Packages(_)));
     }
 
     #[test]
@@ -711,12 +1050,402 @@ mod tests {
     #[test]
     fn parse_preserves_arg_with_spaces() {
         assert!(
-            matches!(Command::parse("chain @scope/pkg"), Command::Chain(ref t) if t == "@scope/pkg")
+            matches!(Command::parse("chain @scope/pkg"), Command::Chain(ref t, _) if t == "@scope/pkg")
         );
     }
 
     #[test]
     fn parse_trims_whitespace() {
         assert!(matches!(Command::parse("  quit  "), Command::Quit));
+    }
+
+    #[test]
+    fn settings_defaults() {
+        let s = ReplSettings::default();
+        assert!(!s.include_dynamic);
+        assert_eq!(s.top, report::DEFAULT_TOP);
+        assert_eq!(s.top_modules, report::DEFAULT_TOP_MODULES);
+        assert!(s.ignore.is_empty());
+    }
+
+    #[test]
+    fn command_options_resolve_uses_settings_when_none() {
+        let settings = ReplSettings::default();
+        let opts = CommandOptions::default();
+        let (trace_opts, top_modules) = opts.resolve(&settings);
+        assert!(!trace_opts.include_dynamic);
+        assert_eq!(trace_opts.top_n, report::DEFAULT_TOP);
+        assert!(trace_opts.ignore.is_empty());
+        assert_eq!(top_modules, report::DEFAULT_TOP_MODULES);
+    }
+
+    #[test]
+    fn command_options_resolve_overrides_settings() {
+        let settings = ReplSettings::default();
+        let opts = CommandOptions {
+            include_dynamic: Some(true),
+            top: Some(5),
+            top_modules: Some(50),
+            ignore: Some(vec!["zod".into()]),
+        };
+        let (trace_opts, top_modules) = opts.resolve(&settings);
+        assert!(trace_opts.include_dynamic);
+        assert_eq!(trace_opts.top_n, 5);
+        assert_eq!(trace_opts.ignore, vec!["zod".to_string()]);
+        assert_eq!(top_modules, 50);
+    }
+
+    #[test]
+    fn parse_flags_no_flags() {
+        let (opts, remaining) = parse_flags(&["src/index.ts"]);
+        assert!(opts.include_dynamic.is_none());
+        assert!(opts.top.is_none());
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_dynamic() {
+        let (opts, remaining) = parse_flags(&["--include-dynamic", "src/index.ts"]);
+        assert_eq!(opts.include_dynamic, Some(true));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_no_dynamic() {
+        let (opts, remaining) = parse_flags(&["--no-include-dynamic", "src/index.ts"]);
+        assert_eq!(opts.include_dynamic, Some(false));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_top() {
+        let (opts, remaining) = parse_flags(&["--top", "5", "src/index.ts"]);
+        assert_eq!(opts.top, Some(5));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_top_modules() {
+        let (opts, remaining) = parse_flags(&["--top-modules", "30", "src/index.ts"]);
+        assert_eq!(opts.top_modules, Some(30));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_ignore() {
+        // --ignore is greedy: consumes all non-flag tokens after it.
+        // Users should put --ignore last or use `set ignore`.
+        let (opts, remaining) = parse_flags(&["src/index.ts", "--ignore", "zod", "lodash"]);
+        assert_eq!(opts.ignore, Some(vec!["zod".into(), "lodash".into()]));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_ignore_stops_at_next_flag() {
+        let (opts, remaining) =
+            parse_flags(&["src/index.ts", "--ignore", "zod", "--include-dynamic"]);
+        assert_eq!(opts.ignore, Some(vec!["zod".to_string()]));
+        assert_eq!(opts.include_dynamic, Some(true));
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_multiple() {
+        let (opts, remaining) = parse_flags(&["--include-dynamic", "--top", "5", "zod"]);
+        assert_eq!(opts.include_dynamic, Some(true));
+        assert_eq!(opts.top, Some(5));
+        assert_eq!(remaining, "zod");
+    }
+
+    #[test]
+    fn parse_flags_empty() {
+        let (opts, remaining) = parse_flags(&[]);
+        assert!(opts.include_dynamic.is_none());
+        assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_flags_only_flags_no_positional() {
+        let (opts, remaining) = parse_flags(&["--include-dynamic"]);
+        assert_eq!(opts.include_dynamic, Some(true));
+        assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_flags_scoped_package_not_treated_as_flag() {
+        let (opts, remaining) = parse_flags(&["@scope/pkg"]);
+        assert!(opts.include_dynamic.is_none());
+        assert_eq!(remaining, "@scope/pkg");
+    }
+
+    #[test]
+    fn parse_flags_top_non_numeric_preserves_positional() {
+        // When --top is followed by a non-numeric token, the token should not
+        // be consumed as the --top value — it stays as a positional arg.
+        let (opts, remaining) = parse_flags(&["--top", "src/index.ts"]);
+        assert!(opts.top.is_none());
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_top_modules_non_numeric_preserves_positional() {
+        let (opts, remaining) = parse_flags(&["--top-modules", "src/index.ts"]);
+        assert!(opts.top_modules.is_none());
+        assert_eq!(remaining, "src/index.ts");
+    }
+
+    #[test]
+    fn parse_flags_top_rejects_negative_below_minus_one() {
+        let (opts, _) = parse_flags(&["--top", "-5", "src/index.ts"]);
+        assert!(opts.top.is_none());
+    }
+
+    #[test]
+    fn parse_flags_top_accepts_negative_one() {
+        let (opts, _) = parse_flags(&["--top", "-1", "src/index.ts"]);
+        assert_eq!(opts.top, Some(-1));
+    }
+
+    #[test]
+    fn parse_flags_top_modules_rejects_negative_below_minus_one() {
+        let (opts, _) = parse_flags(&["--top-modules", "-5", "src/index.ts"]);
+        assert!(opts.top_modules.is_none());
+    }
+
+    #[test]
+    fn parse_flags_top_modules_accepts_negative_one() {
+        let (opts, _) = parse_flags(&["--top-modules", "-1", "src/index.ts"]);
+        assert_eq!(opts.top_modules, Some(-1));
+    }
+
+    #[test]
+    fn parse_trace_with_flags() {
+        let cmd = Command::parse("trace --include-dynamic --top 5 src/index.ts");
+        match cmd {
+            Command::Trace(Some(ref f), ref opts) => {
+                assert_eq!(f, "src/index.ts");
+                assert_eq!(opts.include_dynamic, Some(true));
+                assert_eq!(opts.top, Some(5));
+            }
+            other => panic!("expected Trace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_flags_no_file() {
+        let cmd = Command::parse("trace --include-dynamic");
+        match cmd {
+            Command::Trace(None, ref opts) => {
+                assert_eq!(opts.include_dynamic, Some(true));
+            }
+            other => panic!("expected Trace(None, _), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_chain_with_dynamic() {
+        let cmd = Command::parse("chain --include-dynamic zod");
+        match cmd {
+            Command::Chain(ref target, ref opts) => {
+                assert_eq!(target, "zod");
+                assert_eq!(opts.include_dynamic, Some(true));
+            }
+            other => panic!("expected Chain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cut_with_top() {
+        let cmd = Command::parse("cut --top 3 zod");
+        match cmd {
+            Command::Cut(ref target, ref opts) => {
+                assert_eq!(target, "zod");
+                assert_eq!(opts.top, Some(3));
+            }
+            other => panic!("expected Cut, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_packages_with_top() {
+        let cmd = Command::parse("packages --top 20");
+        match cmd {
+            Command::Packages(ref opts) => {
+                assert_eq!(opts.top, Some(20));
+            }
+            other => panic!("expected Packages, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_set() {
+        assert!(matches!(
+            Command::parse("set dynamic"),
+            Command::Set(ref s) if s == "dynamic"
+        ));
+        assert!(matches!(
+            Command::parse("set top 5"),
+            Command::Set(ref s) if s == "top 5"
+        ));
+    }
+
+    #[test]
+    fn parse_unset() {
+        assert!(matches!(
+            Command::parse("unset ignore"),
+            Command::Unset(ref s) if s == "ignore"
+        ));
+    }
+
+    #[test]
+    fn parse_show() {
+        assert!(matches!(Command::parse("show"), Command::Show));
+    }
+
+    #[test]
+    fn parse_set_missing_arg() {
+        assert!(matches!(Command::parse("set"), Command::Unknown(_)));
+    }
+
+    #[test]
+    fn parse_unset_missing_arg() {
+        assert!(matches!(Command::parse("unset"), Command::Unknown(_)));
+    }
+
+    #[test]
+    fn set_dynamic_toggle() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "dynamic", StderrColor::new(true));
+        assert!(s.include_dynamic);
+        dispatch_set(&mut s, "dynamic", StderrColor::new(true));
+        assert!(!s.include_dynamic);
+    }
+
+    #[test]
+    fn set_dynamic_explicit() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "dynamic true", StderrColor::new(true));
+        assert!(s.include_dynamic);
+        dispatch_set(&mut s, "dynamic false", StderrColor::new(true));
+        assert!(!s.include_dynamic);
+    }
+
+    #[test]
+    fn set_include_dynamic_alias() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "include-dynamic true", StderrColor::new(true));
+        assert!(s.include_dynamic);
+    }
+
+    #[test]
+    fn unset_include_dynamic_alias() {
+        let mut s = ReplSettings {
+            include_dynamic: true,
+            ..ReplSettings::default()
+        };
+        dispatch_unset(&mut s, "include-dynamic", StderrColor::new(true));
+        assert!(!s.include_dynamic);
+    }
+
+    #[test]
+    fn set_top() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top 5", StderrColor::new(true));
+        assert_eq!(s.top, 5);
+    }
+
+    #[test]
+    fn set_top_modules() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top-modules 30", StderrColor::new(true));
+        assert_eq!(s.top_modules, 30);
+    }
+
+    #[test]
+    fn set_top_rejects_invalid_value() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top -5", StderrColor::new(true));
+        // Value should remain at default since -5 < -1.
+        assert_eq!(s.top, report::DEFAULT_TOP);
+    }
+
+    #[test]
+    fn set_top_modules_rejects_invalid_value() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top-modules -2", StderrColor::new(true));
+        assert_eq!(s.top_modules, report::DEFAULT_TOP_MODULES);
+    }
+
+    #[test]
+    fn set_top_accepts_negative_one() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top -1", StderrColor::new(true));
+        assert_eq!(s.top, -1);
+    }
+
+    #[test]
+    fn set_top_accepts_zero() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "top 0", StderrColor::new(true));
+        assert_eq!(s.top, 0);
+    }
+
+    #[test]
+    fn set_ignore() {
+        let mut s = ReplSettings::default();
+        dispatch_set(&mut s, "ignore zod lodash", StderrColor::new(true));
+        assert_eq!(s.ignore, vec!["zod".to_string(), "lodash".to_string()]);
+    }
+
+    #[test]
+    fn unset_dynamic() {
+        let mut s = ReplSettings {
+            include_dynamic: true,
+            ..ReplSettings::default()
+        };
+        dispatch_unset(&mut s, "dynamic", StderrColor::new(true));
+        assert!(!s.include_dynamic);
+    }
+
+    #[test]
+    fn unset_ignore() {
+        let mut s = ReplSettings {
+            ignore: vec!["zod".into()],
+            ..ReplSettings::default()
+        };
+        dispatch_unset(&mut s, "ignore", StderrColor::new(true));
+        assert!(s.ignore.is_empty());
+    }
+
+    #[test]
+    fn unset_top() {
+        let mut s = ReplSettings {
+            top: 99,
+            ..ReplSettings::default()
+        };
+        dispatch_unset(&mut s, "top", StderrColor::new(true));
+        assert_eq!(s.top, report::DEFAULT_TOP);
+    }
+
+    #[test]
+    fn unset_top_modules() {
+        let mut s = ReplSettings {
+            top_modules: 99,
+            ..ReplSettings::default()
+        };
+        dispatch_unset(&mut s, "top-modules", StderrColor::new(true));
+        assert_eq!(s.top_modules, report::DEFAULT_TOP_MODULES);
+    }
+
+    #[test]
+    fn parse_diff_with_dynamic() {
+        let cmd = Command::parse("diff --include-dynamic src/other.ts");
+        match cmd {
+            Command::Diff(ref path, ref opts) => {
+                assert_eq!(path, "src/other.ts");
+                assert_eq!(opts.include_dynamic, Some(true));
+            }
+            other => panic!("expected Diff, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `ReplSettings` struct for persistent session-level defaults (`dynamic`, `top`, `top-modules`, `ignore`) and `CommandOptions` for per-command overrides via inline flags (`--dynamic`, `--top N`, `--top-modules N`, `--ignore pkg...`)
- Add `set`/`unset`/`show` commands for interactive tuning of session settings without restarting
- Wire options through all dispatch functions (`trace`, `chain`, `cut`, `diff`, `packages`) with resolution: per-command override if present, else session default
- Add tab completion for `set`/`unset` option names, update help text with inline flags documentation

## Test Plan
- [x] 48 repl unit tests covering: struct defaults, option resolution, flag parsing (all flag types, edge cases, greedy --ignore), command parsing with flags, set/unset dispatch (toggle, explicit, numeric, list, reset)
- [x] `cargo xtask check` passes (fmt + clippy + 259 workspace tests)
- [ ] Manual smoke test: `chainsaw repl`, then `show`, `set dynamic`, `trace`, `set top 3`, `trace --top 20`, `set ignore zod`, `unset ignore`, `packages --top 5`, `chain --dynamic zod`

Closes #99