### PR TITLE
fix(cli): respect --json flag with --diff-from

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -335,7 +335,11 @@ fn run_trace(args: TraceArgs, color: bool, sc: report::StderrColor) -> Result<()
         let saved = load_snapshot(snapshot_path)?;
         let diff = query::diff_snapshots(&saved, &result.to_snapshot(&entry_rel));
         let report = report::DiffReport::from_diff(&diff, &saved.entry, &entry_rel, args.limit);
-        print!("{}", report.to_terminal(color));
+        if args.json {
+            println!("{}", report.to_json());
+        } else {
+            print!("{}", report.to_terminal(color));
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- The `--diff-from` code path in `trace` always printed terminal output, ignoring the `--json` flag
- Now checks `args.json` and emits `report.to_json()` when set, matching behavior of `--chain`, `--cut`, and normal trace output

Closes #150