### PR TITLE
fix(cli): replace process::exit with error return for --max-weight

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,13 @@ pub enum Error {
     InvalidTopValue(&'static str, i32),
     /// Readline/REPL initialization failed.
     Readline(String),
+    /// --max-weight threshold exceeded.
+    MaxWeightExceeded {
+        kind: &'static str,
+        weight: u64,
+        module_count: usize,
+        threshold: u64,
+    },
 }
 
 impl Error {
@@ -113,6 +120,20 @@ impl std::fmt::Display for Error {
                 write!(f, "invalid value {n} for {flag}: must be -1 (all) or 0+")
             }
             Self::Readline(msg) => write!(f, "readline: {msg}"),
+            Self::MaxWeightExceeded {
+                kind,
+                weight,
+                module_count,
+                threshold,
+            } => {
+                let plural = if *module_count == 1 { "" } else { "s" };
+                write!(
+                    f,
+                    "{kind} transitive weight {} ({module_count} module{plural}) exceeds --max-weight threshold {}",
+                    crate::report::format_size(*weight),
+                    crate::report::format_size(*threshold),
+                )
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,19 +368,12 @@ fn run_trace(args: TraceArgs, color: bool, sc: report::StderrColor) -> Result<()
         } else {
             "static"
         };
-        eprintln!(
-            "{} {kind} transitive weight {} ({} module{}) exceeds --max-weight threshold {}",
-            sc.error("error:"),
-            report::format_size(report.static_weight_bytes),
-            report.static_module_count,
-            if report.static_module_count == 1 {
-                ""
-            } else {
-                "s"
-            },
-            report::format_size(threshold),
-        );
-        std::process::exit(1);
+        return Err(Error::MaxWeightExceeded {
+            kind,
+            weight: report.static_weight_bytes,
+            module_count: report.static_module_count,
+            threshold,
+        });
     }
 
     if !args.quiet {


### PR DESCRIPTION
Closes #148

## Summary
- Add `MaxWeightExceeded` variant to `Error` enum with structured fields (`kind`, `weight`, `module_count`, `threshold`)
- Replace `process::exit(1)` in `run_trace` with `Err(Error::MaxWeightExceeded { .. })` so the error flows through the centralized error handler in `main()`
- The `Display` impl formats the same user-facing message as before, so CLI output is unchanged

## Test plan
- [x] `cargo test --workspace` passes (all 338 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean