### PR TITLE
fix(session): prevent false direct_import for nonexistent targets

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -495,7 +495,9 @@ impl Session {
             target: resolved.label,
             found_in_graph: resolved.exists,
             chain_count: chains.len(),
-            direct_import: cuts.is_empty() && chains.iter().all(|c| c.len() == 2),
+            direct_import: !chains.is_empty()
+                && cuts.is_empty()
+                && chains.iter().all(|c| c.len() == 2),
             cut_points: cuts
                 .iter()
                 .map(|c| CutEntry {
@@ -1000,6 +1002,16 @@ mod tests {
         assert_eq!(report.chain_count, 1);
         assert!(report.direct_import);
         assert!(report.cut_points.is_empty());
+    }
+
+    #[test]
+    fn cut_report_nonexistent_target() {
+        let (_tmp, entry) = test_project();
+        let mut session = Session::open(&entry, true).unwrap();
+        let report = session.cut_report("nonexistent-pkg", 10, false);
+        assert!(!report.found_in_graph);
+        assert_eq!(report.chain_count, 0);
+        assert!(!report.direct_import);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `--cut` is used with a target that doesn't exist in the graph, the `direct_import` field in the report incorrectly returns `true`. This happens because the check `cuts.is_empty() && chains.iter().all(|c| c.len() == 2)` vacuously evaluates to `true` when both `cuts` and `chains` are empty.

The fix adds a `!chains.is_empty()` guard so `direct_import` is only `true` when there are actual import chains confirming a direct dependency.

Closes #151