### PR TITLE
fix(cache): prevent diff from corrupting disk cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -659,13 +659,17 @@ fn build_snapshot_from_ref(
 }
 
 /// Build a snapshot from the current working tree.
+///
+/// Uses `no_cache=true` to avoid polluting the disk cache — the "before"
+/// side of a diff may have written a reduced (git-tree-only) graph, and
+/// the working-tree snapshot must not read or overwrite that entry.
 fn build_snapshot_from_working_tree(
     entry: &Path,
     quiet: bool,
     sc: report::StderrColor,
 ) -> Result<query::TraceSnapshot, Error> {
     let start = Instant::now();
-    let (loaded, _cache_write) = loader::load_graph(entry, false)?;
+    let (loaded, _cache_write) = loader::load_graph(entry, true)?;
     if !quiet {
         print_build_status(&loaded, start, sc);
     }


### PR DESCRIPTION
## Summary

- Pass `no_cache=true` in `build_snapshot_from_working_tree` so the working-tree side of a diff neither reads nor writes the disk cache, preventing cross-contamination from the git-ref side's reduced graph.

Closes #142

## What was happening

When running `chainsaw diff <ref> --entry <file>`, the git-ref side builds a reduced graph (no `node_modules`, read from git tree) and writes it to the disk cache. The working-tree side then calls `loader::load_graph(entry, false)` (no_cache=false), which reads the contaminated cache entry and produces incorrect results. Subsequent `chainsaw trace` commands also read the corrupted cache until it is manually cleared.

## The fix

Change the `no_cache` argument from `false` to `true` in `build_snapshot_from_working_tree`, matching the behavior already used by `build_snapshot_from_ref`. This ensures neither side of a diff pollutes the shared cache.

## Test plan

- [x] `cargo test --workspace` passes (all 274 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (via pre-commit hook)
- [ ] Manual: `chainsaw diff HEAD~1 --entry <file>` followed by `chainsaw trace <file>` produces correct, consistent results