### PR TITLE
chore(cargo): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainsaw-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "bitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask", "stats"]
 
 [package]
 name = "chainsaw-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.91"
 description = "Trace transitive import weight in TypeScript and Python codebases"


### PR DESCRIPTION
## Summary
- Bump version from 0.3.0 to 0.4.0 for release

## Test plan
- [x] `cargo check` passes
- [x] All 425 tests pass
- [x] Clippy clean
- [x] `cargo publish --dry-run` clean