### PR TITLE
chore: move developer-local ignores to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /target
 .chainsaw.cache
-CLAUDE.md
-docs/plans/
-.worktrees/


### PR DESCRIPTION
Move developer-local ignore patterns to the global gitignore where they belong.